### PR TITLE
Shabbir | Removed the transform from sides as it is moving the cards out of parent div

### DIFF
--- a/open_hub/openhub/static/css/style.css
+++ b/open_hub/openhub/static/css/style.css
@@ -35,8 +35,8 @@ p {
   overflow: hidden;
   opacity: 0;
   margin-top: 70px;
-  -webkit-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
+  -webkit-transform: translate(0%, -50%);
+  transform: translate(0%, -50%);
   -webkit-border-radius: 50%;
   border-radius: 50%;
   -webkit-box-shadow: 0px 3px 6px rgba(0, 0, 0, 0.16), 0px 3px 6px rgba(0, 0, 0, 0.23);


### PR DESCRIPTION
I have changed the transform as the profile card is just being used once in all the template. Ideally, we shouldn't be using transform at all because to make the CSS more re-usable.